### PR TITLE
Concurrency fix for MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ wayland = ["smithay-clipboard", "wayland-client"]
 clipboard-win = "2.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+lazy_static = "1.4"
 objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -9,15 +9,8 @@ fn some_other_fn() {
 mod tests {
     use super::*;
 
-    fn clear_clipboard() {
-        let mut clipboard: ClipboardContext = ClipboardContext::new().unwrap();
-        clipboard.set_contents("".into()).unwrap();
-    }
-
     #[test]
     fn foo() {
-        clear_clipboard();
-
         let mut ctx = ClipboardContext::new().unwrap();
         ctx.set_contents("Dummy".into()).unwrap();
         ctx.get_contents().unwrap();
@@ -27,8 +20,6 @@ mod tests {
 
     #[test]
     fn bar() {
-        clear_clipboard();
-
         let mut ctx = ClipboardContext::new().unwrap();
         ctx.set_contents("Dummy".into()).unwrap();
         ctx.get_contents().unwrap();

--- a/tests/failing.rs
+++ b/tests/failing.rs
@@ -1,0 +1,38 @@
+use copypasta::{ClipboardContext, ClipboardProvider};
+
+fn some_other_fn() {
+    let mut ctx = ClipboardContext::new().unwrap();
+    ctx.get_contents().unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clear_clipboard() {
+        let mut clipboard: ClipboardContext = ClipboardContext::new().unwrap();
+        clipboard.set_contents("".into()).unwrap();
+    }
+
+    #[test]
+    fn foo() {
+        clear_clipboard();
+
+        let mut ctx = ClipboardContext::new().unwrap();
+        ctx.set_contents("Dummy".into()).unwrap();
+        ctx.get_contents().unwrap();
+
+        some_other_fn();
+    }
+
+    #[test]
+    fn bar() {
+        clear_clipboard();
+
+        let mut ctx = ClipboardContext::new().unwrap();
+        ctx.set_contents("Dummy".into()).unwrap();
+        ctx.get_contents().unwrap();
+
+        some_other_fn();
+    }
+}


### PR DESCRIPTION
This is a fix for #11.

I needed to wrap all NSPasteboard access in this mutex, including the `new()` fn. I've used a global mutex for this, wrapped in a `lazy_static!`.

Edit: Hmm, no, apparently even WITH a Mutex around it, it's still failing intermittently :( It appears that even a global Mutex isn't enough, it's simply failing even when multiple pasteboard instances are being created and used. The only way I can get my test to reliably work is if have a shared `Arc<Mutex<ClipboardContext>>` and re-use that everywhere. Simply creating multiple ClipboardContexts will eventually fail.