### PR TITLE
Add Send + Sync + 'static bounds to dyn Error

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -14,11 +14,13 @@
 
 use std::error::Error;
 
+pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
 // TODO: come up with some platform-agnostic API for richer types
 /// Trait for clipboard access
 pub trait ClipboardProvider: Send {
     /// Method to get the clipboard contents as a String
-    fn get_contents(&mut self) -> Result<String, Box<dyn Error>>;
+    fn get_contents(&mut self) -> Result<String>;
     /// Method to set the clipboard contents as a String
-    fn set_contents(&mut self, _: String) -> Result<(), Box<dyn Error>>;
+    fn set_contents(&mut self, _: String) -> Result<()>;
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,7 +14,7 @@
 
 use std::error::Error;
 
-pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
+pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync + 'static>>;
 
 // TODO: come up with some platform-agnostic API for richer types
 /// Trait for clipboard access

--- a/src/nop_clipboard.rs
+++ b/src/nop_clipboard.rs
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
-
-use crate::common::ClipboardProvider;
+use crate::common::{ClipboardProvider, Result};
 
 pub struct NopClipboardContext;
 
 impl NopClipboardContext {
-    pub fn new() -> Result<NopClipboardContext, Box<dyn Error>> {
+    pub fn new() -> Result<NopClipboardContext> {
         Ok(NopClipboardContext)
     }
 }
 
 impl ClipboardProvider for NopClipboardContext {
-    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_contents(&mut self) -> Result<String> {
         println!(
             "Attempting to get the contents of the clipboard, which hasn't yet been implemented \
              on this platform."
@@ -33,7 +31,7 @@ impl ClipboardProvider for NopClipboardContext {
         Ok("".to_string())
     }
 
-    fn set_contents(&mut self, _: String) -> Result<(), Box<dyn Error>> {
+    fn set_contents(&mut self, _: String) -> Result<()> {
         println!(
             "Attempting to set the contents of the clipboard, which hasn't yet been implemented \
              on this platform."

--- a/src/osx_clipboard.rs
+++ b/src/osx_clipboard.rs
@@ -32,7 +32,7 @@ pub struct OSXClipboardContext {
 extern "C" {}
 
 impl OSXClipboardContext {
-    pub fn new() -> Result<OSXClipboardContext, Box<dyn Error>> {
+    pub fn new() -> Result<OSXClipboardContext> {
         let cls = Class::get("NSPasteboard").ok_or("Class::get(\"NSPasteboard\")")?;
         let pasteboard: *mut Object = unsafe { msg_send![cls, generalPasteboard] };
         if pasteboard.is_null() {
@@ -44,7 +44,7 @@ impl OSXClipboardContext {
 }
 
 impl ClipboardProvider for OSXClipboardContext {
-    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_contents(&mut self) -> Result<String> {
         let string_class: Id<NSObject> = {
             let cls: Id<Class> = unsafe { Id::from_ptr(class("NSString")) };
             unsafe { transmute(cls) }
@@ -66,7 +66,7 @@ impl ClipboardProvider for OSXClipboardContext {
         }
     }
 
-    fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+    fn set_contents(&mut self, data: String) -> Result<()> {
         let string_array = NSArray::from_vec(vec![NSString::from_str(&data)]);
         let _: usize = unsafe { msg_send![self.pasteboard, clearContents] };
         let success: bool = unsafe { msg_send![self.pasteboard, writeObjects: string_array] };

--- a/src/wayland_clipboard.rs
+++ b/src/wayland_clipboard.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
 use std::ffi::c_void;
 use std::sync::{Arc, Mutex};
 
 use smithay_clipboard::Clipboard as WaylandClipboard;
 
-use crate::common::ClipboardProvider;
+use crate::common::{ClipboardProvider, Result};
 
 pub struct Clipboard {
     context: Arc<Mutex<WaylandClipboard>>,
@@ -41,11 +40,11 @@ pub unsafe fn create_clipboards_from_external(display: *mut c_void) -> (Primary,
 }
 
 impl ClipboardProvider for Clipboard {
-    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_contents(&mut self) -> Result<String> {
         Ok(self.context.lock().unwrap().load()?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+    fn set_contents(&mut self, data: String) -> Result<()> {
         self.context.lock().unwrap().store(data);
 
         Ok(())
@@ -53,11 +52,11 @@ impl ClipboardProvider for Clipboard {
 }
 
 impl ClipboardProvider for Primary {
-    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_contents(&mut self) -> Result<String> {
         Ok(self.context.lock().unwrap().load_primary()?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+    fn set_contents(&mut self, data: String) -> Result<()> {
         self.context.lock().unwrap().store_primary(data);
 
         Ok(())

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -16,22 +16,22 @@ use std::error::Error;
 
 use clipboard_win::{get_clipboard_string, set_clipboard_string};
 
-use crate::common::ClipboardProvider;
+use crate::common::{ClipboardProvider, Result};
 
 pub struct WindowsClipboardContext;
 
 impl WindowsClipboardContext {
-    pub fn new() -> Result<Self, Box<dyn Error>> {
+    pub fn new() -> Result<Self> {
         Ok(WindowsClipboardContext)
     }
 }
 
 impl ClipboardProvider for WindowsClipboardContext {
-    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_contents(&mut self) -> Result<String> {
         Ok(get_clipboard_string()?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+    fn set_contents(&mut self, data: String) -> Result<()> {
         Ok(set_clipboard_string(&data)?)
     }
 }

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
 use std::marker::PhantomData;
 use std::time::Duration;
 
@@ -49,7 +48,7 @@ impl<S> X11ClipboardContext<S>
 where
     S: Selection,
 {
-    pub fn new() -> Result<X11ClipboardContext<S>, Box<dyn Error>> {
+    pub fn new() -> Result<X11ClipboardContext<S>> {
         Ok(X11ClipboardContext(X11Clipboard::new()?, PhantomData))
     }
 }
@@ -58,7 +57,7 @@ impl<S> ClipboardProvider for X11ClipboardContext<S>
 where
     S: Selection,
 {
-    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_contents(&mut self) -> Result<String> {
         Ok(String::from_utf8(self.0.load(
             S::atom(&self.0.getter.atoms),
             self.0.getter.atoms.utf8_string,
@@ -67,7 +66,7 @@ where
         )?)?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+    fn set_contents(&mut self, data: String) -> Result<()> {
         Ok(self.0.store(S::atom(&self.0.setter.atoms), self.0.setter.atoms.utf8_string, data)?)
     }
 }


### PR DESCRIPTION
Add `Send + Sync + 'static` bounds to the error type, i. e. change `dyn Error` to `dyn Error + Send + Sync + 'static`.

~~It also adds a basic test.~~

Fixes #17 