### PR TITLE
Reduce number of GitHub Actions CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,30 +9,19 @@ jobs:
   build:
     strategy:
       matrix:
-        rust_version: [stable, 1.43.1]
         os: [windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Rustup
-        run: rustup default ${{ matrix.rust_version }}
-      - name: Test
+      - name: Stable
         run: cargo test
-
-  clippy:
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest]
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Rustup
-        run: rustup default ${{ matrix.rust_version }}
-      - name: Install Clippy
-        run: rustup component add clippy
-      - name: Lint
-        run: cargo clippy --all-targets
+      - name: Clippy
+        run: |
+          rustup component add clippy
+          cargo clippy --all-targets
+      - name: Oldstable
+        run: |
+          rustup default 1.43.1
+          cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Oldstable
         run: |
           rustup default 1.43.1
+          cargo clean
           cargo test

--- a/src/osx_clipboard.rs
+++ b/src/osx_clipboard.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
 use std::mem::transmute;
 
 use objc::runtime::{Class, Object};


### PR DESCRIPTION
By reducing the number of CI jobs for GitHub actions, it should be
possible to get a faster overview over the status of all CI jobs. While
this does increase the total build time of GitHub Actions by reducing
parallelization, it should still finish within the SourceHut CI times.