### PR TITLE
fix mac os memory leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clipboard-win = "3.0.2"
 objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
+libc = "0.2"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="ios", target_os="emscripten"))))'.dependencies]
 x11-clipboard = { version = "0.5.1", optional = true }


### PR DESCRIPTION
TLDR;
I did not find an easy way to clean up NSArray, but there is a better option to get NSString from pasteboard - stringForType.

Next up. Even if send release to NSString, there are leftovers after conversion NSString to Rust string. Right now, conversion happens in INSString.as_str(), which internally uses NSString.UTF8String. UTF8String, according to Apple docs, is a pointer lifetime of which is less or equal NSString. This is not true if the clipboard contains characters outside the ASCII range. That's why nsstring_to_rust_string function.

I tried to describe the full process in a [blogpost](https://barhamon.com/post/rust_and_nsstring) 