### PR TITLE
Fix crash on use-after-free on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 0.8.0
+## Unreleased 
+
+### Fixed
+
+- Crash on use-after-free on macOS
+
+## 0.8.0
 
 ### Packaging
 


### PR DESCRIPTION
The code is inspired by glfw NSPasteboard clipboard loading.

Fixes alacritty/alacritty#6141.