### PR TITLE
Bump x11-clipboard to 0.7.0

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -25,5 +25,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.57.0
-      cargo +1.57.0 test
+      rustup toolchain install --profile minimal 1.60.0
+      cargo +1.60.0 test

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -26,5 +26,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.57.0
-      cargo +1.57.0 test
+      rustup toolchain install --profile minimal 1.60.0
+      cargo +1.60.0 test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
           cargo clippy --all-targets
       - name: Oldstable
         run: |
-          rustup default 1.57.0
+          rustup default 1.60.0
           cargo clean
           cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Packaging
+
+- Minimum rust version was bumped to `1.60.0`
+
 ## 0.8.1 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimum rust version was bumped to `1.60.0`
 
+### Fixed
+
+- `x11_clipboard` was bumped to `0.7.0` droping `quick-xml` from the deps tree
+
+
 ## 0.8.1 
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="ios", target_os="emscripten"))))'.dependencies]
-x11-clipboard = { version = "0.6.1", optional = true }
+x11-clipboard = { version = "0.7.0", optional = true }
 smithay-clipboard = { version = "0.6.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT / Apache-2.0"
 keywords = ["clipboard"]
 exclude = ["/.travis.yml"]
 edition = "2021"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 [features]
 default = ["x11", "wayland"]

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -15,7 +15,7 @@
 use std::marker::PhantomData;
 use std::time::Duration;
 
-use x11_clipboard::xcb::x::Atom;
+use x11_clipboard::Atom;
 use x11_clipboard::{Atoms, Clipboard as X11Clipboard};
 
 use crate::common::*;


### PR DESCRIPTION
This should remove `quick-xml` from the dependency tree, which is time bombed by the rust now.

--

Not sure how to describe this. Also, @chrisduerr could you give this a bit testing, given that it seems like they rewrote a crate a bit? I have tested that it works fine on XWayland for both
Clipboard and selection providers, but it was more of a brief testing.