### PR TITLE
Change signature of `set_contents()` with `AsRef<str>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Bump minimum supported Rust version to `1.61.0`
+- Change `ClipboardProvider::set_contents` parameter type to `AsRef<str>`
 
 ## 0.8.2
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ fn main() {
     let mut ctx = ClipboardContext::new().unwrap();
 
     let msg = "Hello, world!";
-    ctx.set_contents(msg.to_owned()).unwrap();
+    ctx.set_contents(msg).unwrap();
 
     let content = ctx.get_contents().unwrap();
 
@@ -29,7 +29,7 @@ The `ClipboardProvider` trait has the following functions:
 
 ```rust
 fn get_contents(&mut self) -> Result<String, Box<Error>>;
-fn set_contents(&mut self, String) -> Result<(), Box<Error>>;
+fn set_contents<T: AsRef<str>>(&mut self, T) -> Result<(), Box<Error>>;
 ```
 
 `ClipboardContext` is a type alias for one of {`WindowsClipboardContext`, `OSXClipboardContext`, `X11ClipboardContext`, `NopClipboardContext`}, all of which implement `ClipboardProvider`. Which concrete type is chosen for `ClipboardContext` depends on the OS (via conditional compilation).

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,7 @@ fn main() {
     let mut ctx = ClipboardContext::new().unwrap();
 
     let msg = "Hello, world!";
-    ctx.set_contents(msg.to_owned()).unwrap();
+    ctx.set_contents(msg).unwrap();
 
     let content = ctx.get_contents().unwrap();
 

--- a/examples/primary_selection.rs
+++ b/examples/primary_selection.rs
@@ -9,7 +9,7 @@ fn main() {
 
     let the_string = "Hello, world!";
 
-    ctx.set_contents(the_string.to_owned()).unwrap();
+    ctx.set_contents(the_string).unwrap();
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/common.rs
+++ b/src/common.rs
@@ -22,5 +22,5 @@ pub trait ClipboardProvider: Send {
     /// Method to get the clipboard contents as a String
     fn get_contents(&mut self) -> Result<String>;
     /// Method to set the clipboard contents as a String
-    fn set_contents(&mut self, _: String) -> Result<()>;
+    fn set_contents<T: AsRef<str>>(&mut self, _: T) -> Result<()>;
 }

--- a/src/nop_clipboard.rs
+++ b/src/nop_clipboard.rs
@@ -31,7 +31,7 @@ impl ClipboardProvider for NopClipboardContext {
         Ok("".to_string())
     }
 
-    fn set_contents(&mut self, _: String) -> Result<()> {
+    fn set_contents<T: AsRef<str>>(&mut self, _: T) -> Result<()> {
         println!(
             "Attempting to set the contents of the clipboard, which hasn't yet been implemented \
              on this platform."

--- a/src/osx_clipboard.rs
+++ b/src/osx_clipboard.rs
@@ -64,8 +64,8 @@ impl ClipboardProvider for OSXClipboardContext {
         })
     }
 
-    fn set_contents(&mut self, data: String) -> Result<()> {
-        let string_array = NSArray::from_vec(vec![NSString::from_str(&data)]);
+    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
+        let string_array = NSArray::from_vec(vec![NSString::from_str(data.as_ref())]);
         let _: usize = unsafe { msg_send![self.pasteboard, clearContents] };
         let success: bool = unsafe { msg_send![self.pasteboard, writeObjects: string_array] };
         if success {

--- a/src/wayland_clipboard.rs
+++ b/src/wayland_clipboard.rs
@@ -44,8 +44,8 @@ impl ClipboardProvider for Clipboard {
         Ok(self.context.lock().unwrap().load()?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<()> {
-        self.context.lock().unwrap().store(data);
+    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
+        self.context.lock().unwrap().store(data.as_ref());
 
         Ok(())
     }
@@ -56,8 +56,8 @@ impl ClipboardProvider for Primary {
         Ok(self.context.lock().unwrap().load_primary()?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<()> {
-        self.context.lock().unwrap().store_primary(data);
+    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
+        self.context.lock().unwrap().store_primary(data.as_ref());
 
         Ok(())
     }

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -29,7 +29,7 @@ impl ClipboardProvider for WindowsClipboardContext {
         Ok(get_clipboard_string()?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<()> {
-        Ok(set_clipboard_string(&data)?)
+    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
+        Ok(set_clipboard_string(data.as_ref())?)
     }
 }

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -66,7 +66,7 @@ where
         )?)?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<()> {
-        Ok(self.0.store(S::atom(&self.0.setter.atoms), self.0.setter.atoms.utf8_string, data)?)
+    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
+        Ok(self.0.store(S::atom(&self.0.setter.atoms), self.0.setter.atoms.utf8_string, data.as_ref())?)
     }
 }

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -67,6 +67,10 @@ where
     }
 
     fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
-        Ok(self.0.store(S::atom(&self.0.setter.atoms), self.0.setter.atoms.utf8_string, data.as_ref())?)
+        Ok(self.0.store(
+            S::atom(&self.0.setter.atoms),
+            self.0.setter.atoms.utf8_string,
+            data.as_ref(),
+        )?)
     }
 }


### PR DESCRIPTION
Previously, `set_contents()` takes ownership of `String` as the first argument, so we had to pass cloned or owned strings like this:

```rust
ctx.set_contents(String::from("abc"));

// Or

ctx.set_contents("abc".to_owned());
```

This is a bit cumbersome and I wonder we can pass just string references like this:

```rust
ctx.set_contents("abc");
```

From this motivation, I created a patch to change the signature of `set_contents()` and made the function receive an arugment with the constraint of `AsRef<str>`.

I think this patch doesn't cause breaking changes because the user of this library can still pass owned version of strings.