### PR TITLE
Bump minimum supported Rust version to 1.61.0

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -25,5 +25,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.60.0
-      cargo +1.60.0 test
+      rustup toolchain install --profile minimal 1.61.0
+      cargo +1.61.0 test

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -26,5 +26,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.60.0
-      cargo +1.60.0 test
+      rustup toolchain install --profile minimal 1.61.0
+      cargo +1.61.0 test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
           cargo clippy --all-targets
       - name: Oldstable
         run: |
-          rustup default 1.60.0
+          rustup default 1.61.0
           cargo clean
           cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Bump minimum supported Rust version to `1.61.0`
+
 ## 0.8.2
 
 ### Packaging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT / Apache-2.0"
 keywords = ["clipboard"]
 exclude = ["/.travis.yml"]
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 
 [features]
 default = ["x11", "wayland"]


### PR DESCRIPTION
According to the [build](https://builds.sr.ht/~undeadleech/job/1055130#task-oldstable) for #57,  the minimum supported Rust version (MSRV) is `1.61.0` in the latest version of [memchr](https://crates.io/crates/memchr/). I'm not sure the Rust version policy of copypasta, but I want to suggest increasing MSRV to make the build succeed.

What do you think? Rust 1.61.0 was [released on May 19, 2022](https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html) while Rust 1.60.0 was [released on Apr. 7, 2022](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html).