### PR TITLE
Revert "Accept references for `set_contents`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Use `String` in `ClipboardProvider::set_contents` for trait to be *object-safe*
+
 ## 0.9.0
 
 - Bump minimum supported Rust version to `1.65.0`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ fn main() {
     let mut ctx = ClipboardContext::new().unwrap();
 
     let msg = "Hello, world!";
-    ctx.set_contents(msg).unwrap();
+    ctx.set_contents(msg.to_owned()).unwrap();
 
     let content = ctx.get_contents().unwrap();
 
@@ -29,7 +29,7 @@ The `ClipboardProvider` trait has the following functions:
 
 ```rust
 fn get_contents(&mut self) -> Result<String, Box<Error>>;
-fn set_contents<T: AsRef<str>>(&mut self, T) -> Result<(), Box<Error>>;
+fn set_contents(&mut self, String) -> Result<(), Box<Error>>;
 ```
 
 `ClipboardContext` is a type alias for one of {`WindowsClipboardContext`, `OSXClipboardContext`, `X11ClipboardContext`, `NopClipboardContext`}, all of which implement `ClipboardProvider`. Which concrete type is chosen for `ClipboardContext` depends on the OS (via conditional compilation).

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,7 @@ fn main() {
     let mut ctx = ClipboardContext::new().unwrap();
 
     let msg = "Hello, world!";
-    ctx.set_contents(msg).unwrap();
+    ctx.set_contents(msg.to_owned()).unwrap();
 
     let content = ctx.get_contents().unwrap();
 

--- a/examples/primary_selection.rs
+++ b/examples/primary_selection.rs
@@ -9,7 +9,7 @@ fn main() {
 
     let the_string = "Hello, world!";
 
-    ctx.set_contents(the_string).unwrap();
+    ctx.set_contents(the_string.to_owned()).unwrap();
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/common.rs
+++ b/src/common.rs
@@ -22,5 +22,5 @@ pub trait ClipboardProvider: Send {
     /// Method to get the clipboard contents as a String
     fn get_contents(&mut self) -> Result<String>;
     /// Method to set the clipboard contents as a String
-    fn set_contents<T: AsRef<str>>(&mut self, _: T) -> Result<()>;
+    fn set_contents(&mut self, _: String) -> Result<()>;
 }

--- a/src/nop_clipboard.rs
+++ b/src/nop_clipboard.rs
@@ -31,7 +31,7 @@ impl ClipboardProvider for NopClipboardContext {
         Ok("".to_string())
     }
 
-    fn set_contents<T: AsRef<str>>(&mut self, _: T) -> Result<()> {
+    fn set_contents(&mut self, _: String) -> Result<()> {
         println!(
             "Attempting to set the contents of the clipboard, which hasn't yet been implemented \
              on this platform."

--- a/src/osx_clipboard.rs
+++ b/src/osx_clipboard.rs
@@ -76,8 +76,8 @@ impl ClipboardProvider for OSXClipboardContext {
         })
     }
 
-    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
-        let string_array = NSArray::from_vec(vec![NSString::from_str(data.as_ref())]);
+    fn set_contents(&mut self, data: String) -> Result<()> {
+        let string_array = NSArray::from_vec(vec![NSString::from_str(&data)]);
         let _: usize = unsafe { msg_send![self.pasteboard, clearContents] };
         let success: bool = unsafe { msg_send![self.pasteboard, writeObjects: string_array] };
         if success {

--- a/src/wayland_clipboard.rs
+++ b/src/wayland_clipboard.rs
@@ -44,8 +44,8 @@ impl ClipboardProvider for Clipboard {
         Ok(self.context.lock().unwrap().load()?)
     }
 
-    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
-        self.context.lock().unwrap().store(data.as_ref());
+    fn set_contents(&mut self, data: String) -> Result<()> {
+        self.context.lock().unwrap().store(data);
 
         Ok(())
     }
@@ -56,8 +56,8 @@ impl ClipboardProvider for Primary {
         Ok(self.context.lock().unwrap().load_primary()?)
     }
 
-    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
-        self.context.lock().unwrap().store_primary(data.as_ref());
+    fn set_contents(&mut self, data: String) -> Result<()> {
+        self.context.lock().unwrap().store_primary(data);
 
         Ok(())
     }

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -29,7 +29,7 @@ impl ClipboardProvider for WindowsClipboardContext {
         Ok(get_clipboard_string()?)
     }
 
-    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
-        Ok(set_clipboard_string(data.as_ref())?)
+    fn set_contents(&mut self, data: String) -> Result<()> {
+        Ok(set_clipboard_string(&data)?)
     }
 }

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -66,11 +66,7 @@ where
         )?)?)
     }
 
-    fn set_contents<T: AsRef<str>>(&mut self, data: T) -> Result<()> {
-        Ok(self.0.store(
-            S::atom(&self.0.setter.atoms),
-            self.0.setter.atoms.utf8_string,
-            data.as_ref(),
-        )?)
+    fn set_contents(&mut self, data: String) -> Result<()> {
+        Ok(self.0.store(S::atom(&self.0.setter.atoms), self.0.setter.atoms.utf8_string, data)?)
     }
 }


### PR DESCRIPTION
When using generic in a trait the trait becomes not object-safe forcing generics or static dispatch in a such code. For a crate like copypasta that's something we don't really want to, since it's usually self-contained and has different clipboard providers.

This reverts commit 10f1137730345fdca29b506415bdbbe62b719a91.