### PR TITLE
Bump clipboard-win from v3.0.2 to v4.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ x11 = ["x11-clipboard"]
 wayland = ["smithay-clipboard"]
 
 [target.'cfg(windows)'.dependencies]
-clipboard-win = "3.0.2"
+clipboard-win = "4.5.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -12,9 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clipboard_win::{get_clipboard_string, set_clipboard_string};
+use std::error::Error;
+use std::fmt;
+
+use clipboard_win::{get_clipboard_string, set_clipboard_string, SystemError};
 
 use crate::common::{ClipboardProvider, Result};
+
+// Wrap `clipboard_win::SystemError` since it does not implement `Error` trait
+struct WindowsSystemError(SystemError);
+
+impl fmt::Debug for WindowsSystemError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for WindowsSystemError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for WindowsSystemError {}
 
 pub struct WindowsClipboardContext;
 
@@ -26,10 +46,10 @@ impl WindowsClipboardContext {
 
 impl ClipboardProvider for WindowsClipboardContext {
     fn get_contents(&mut self) -> Result<String> {
-        Ok(get_clipboard_string()?)
+        Ok(get_clipboard_string().map_err(WindowsSystemError)?)
     }
 
     fn set_contents(&mut self, data: String) -> Result<()> {
-        Ok(set_clipboard_string(&data)?)
+        Ok(set_clipboard_string(&data).map_err(WindowsSystemError)?)
     }
 }


### PR DESCRIPTION
I confirmed examples worked on my Windows 10 machine.

Small trick in this patch is that `clipboard_win::SystemError` does not implement `std::error::Error` so we need to wrap the error instance by ourselves. This should be okay because the wrapped error instance is hidden by `Box<dyn Error>` trait object.

Fixes #65