### PR TITLE
Update `x11-clipboard` to `0.9.1`

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -25,5 +25,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.65.0
-      cargo +1.65.0 test
+      rustup toolchain install --profile minimal 1.66.0
+      cargo +1.66.0 test

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -26,5 +26,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.65.0
-      cargo +1.65.0 test
+      rustup toolchain install --profile minimal 1.66.0
+      cargo +1.66.0 test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Packaging
 
 - Minimum rust version was bumped to `1.66.0`
+- `x11_clipboard` was bumped to `0.9.1`
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Packaging
+
+- Minimum rust version was bumped to `1.66.0`
+
 ## 0.10.0
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="ios", target_os="emscripten"))))'.dependencies]
-x11-clipboard = { version = "0.8.1", optional = true }
+x11-clipboard = { version = "0.9.1", optional = true }
 smithay-clipboard = { version = "0.7.0", optional = true }


### PR DESCRIPTION
This updated the minimum supported rust version on X11 from `1.65` to `1.66`.

If possible, it would be nice to publish a minor release with this update, as it resolves some duplicated dependencies when using `copypasta` together with latest `winit 0.29`.