### PR TITLE
Use `objc2` and its framework crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,13 @@ wayland = ["smithay-clipboard"]
 clipboard-win = "3.0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc = "0.2"
-objc_id = "0.1"
-objc-foundation = "0.1"
+objc2 = "0.5.1"
+objc2-foundation = { version = "0.2.0", features = [
+    "NSArray",
+    "NSString",
+    "NSURL",
+] }
+objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="ios", target_os="emscripten"))))'.dependencies]
 x11-clipboard = { version = "0.9.1", optional = true }


### PR DESCRIPTION
This catches a few extra error cases related to paths, as well as making it easier to ensure that memory management rules are upheld.

Concretely, it fixes a leak in the passing of the `NSArray` to `writeObjects`.