### PR TITLE
Add wayland-dlopen feature switch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ edition = "2021"
 rust-version = "1.65.0"
 
 [features]
-default = ["x11", "wayland"]
+default = ["x11", "wayland", "wayland-dlopen"]
 x11 = ["x11-clipboard"]
 wayland = ["smithay-clipboard"]
+wayland-dlopen = ["smithay-clipboard/dlopen"]
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = "3.0.2"
@@ -31,4 +32,4 @@ objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="ios", target_os="emscripten"))))'.dependencies]
 x11-clipboard = { version = "0.9.1", optional = true }
-smithay-clipboard = { version = "0.7.0", optional = true }
+smithay-clipboard = { version = "0.7.0", default-features = false, optional = true }


### PR DESCRIPTION
This feature controls whether to load `libwayland` at runtime using `dlopen` instead of linking with it.

Before this commit the library always used `dlopen`.