### PR TITLE
Prepare for objc2 frameworks v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,16 @@ clipboard-win = "3.0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", features = [
+objc2-foundation = { version = "0.2.0", default-features = false, features = [
+    "std",
     "NSArray",
     "NSString",
     "NSURL",
 ] }
-objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard"] }
+objc2-app-kit = { version = "0.2.0", default-features = false, features = [
+    "std",
+    "NSPasteboard",
+] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="ios", target_os="emscripten"))))'.dependencies]
 x11-clipboard = { version = "0.9.1", optional = true }


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).