### PR TITLE
update version of clipbaord-win

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -25,5 +25,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.66.0
-      cargo +1.66.0 test
+      rustup toolchain install --profile minimal 1.71.0
+      cargo +1.71.0 test

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -26,5 +26,5 @@ tasks:
       cargo clippy --all-targets
   - oldstable: |
       cd copypasta
-      rustup toolchain install --profile minimal 1.66.0
-      cargo +1.66.0 test
+      rustup toolchain install --profile minimal 1.71.0
+      cargo +1.71.0 test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
           cargo clippy --all-targets
       - name: Oldstable
         run: |
-          rustup default 1.65.0
+          rustup default 1.71.0
           cargo clean
           cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ wayland = ["smithay-clipboard"]
 wayland-dlopen = ["smithay-clipboard/dlopen"]
 
 [target.'cfg(windows)'.dependencies]
-clipboard-win = "3.0.2"
+clipboard-win = { version = "5.4.0", features = ["std"]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT / Apache-2.0"
 keywords = ["clipboard"]
 exclude = ["/.travis.yml"]
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.71.0"
 
 [features]
 default = ["x11", "wayland", "wayland-dlopen"]


### PR DESCRIPTION
The line `features = ["std"]` has to be there for the lib `error-code` to impl `Error` for `ErrorCode` which is needed because `get_clipboard_string() -> Result<T, ErrorCode>`.

This fixes: [https://github.com/alacritty/alacritty/issues/8319](https://github.com/alacritty/alacritty/issues/8319)