### PR TITLE
Suppress spurious `x11_clipboard` `Error::Owner` errors

### DIFF
--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -15,6 +15,7 @@
 use std::marker::PhantomData;
 use std::time::Duration;
 
+use x11_clipboard::error::Error;
 use x11_clipboard::Atom;
 use x11_clipboard::{Atoms, Clipboard as X11Clipboard};
 
@@ -67,6 +68,16 @@ where
     }
 
     fn set_contents(&mut self, data: String) -> Result<()> {
-        Ok(self.0.store(S::atom(&self.0.setter.atoms), self.0.setter.atoms.utf8_string, data)?)
+        self.0.store(S::atom(&self.0.setter.atoms), self.0.setter.atoms.utf8_string, data).or_else(
+            |err| match err {
+                // The `Owner` error can be spurious, caused by a racy
+                // ownership check. The "store" will still have
+                // happened, so it is safe to ignore.
+                // https://github.com/quininer/x11-clipboard/pull/53 has
+                // more details.
+                Error::Owner => Ok(()),
+                e => Err(e.into()),
+            },
+        )
     }
 }


### PR DESCRIPTION
The `x11_clipboard::Clipboard::store()` method has a racy ownership check that is causing spurious warnings to be emitted in alacritty [0]. `x11_clipboard` is unwilling to accept a fix for the issue [1], citing "maintenance mode".

Let's do the next best thing and ignore the error in our clipboard wrapper: for our intents and purposes this variant serves no purpose, because it only detects clipboard ownership changes *after* contents have already been stored, at which point the job could equally well be considered done.

[0] https://github.com/alacritty/alacritty/issues/6978
[1] https://github.com/quininer/x11-clipboard/pull/53